### PR TITLE
Fix hero CTA layout and hide booking login

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -94,7 +94,7 @@ const About = () => {
             {/* Logo statt CC Kreise - MOBILE OPTIMIERT */}
             <div className="relative mx-auto w-48 sm:w-64 md:w-full md:max-w-md">
               <div className="aspect-square rounded-full bg-gradient-to-br from-gold/20 to-transparent p-6 md:p-8">
-                <div className="h-full w-full rounded-full bg-gradient-to-tr from-dark-gray to-black flex items-center justify-center">
+                <div className="h-full w-full aspect-square rounded-full bg-gradient-to-tr from-dark-gray to-black flex items-center justify-center">
                   {/* LOGOKLEIN mit Animation - RESPONSIVE SIZES */}
                   <motion.img 
                     src={logoKlein} 

--- a/src/components/BookingWidget.jsx
+++ b/src/components/BookingWidget.jsx
@@ -37,9 +37,10 @@ const BookingWidget = () => {
         "datepicker":"top_calendar",
         "is_rtl":false,
         "app_config":{
-          "clear_session":0,
           "allow_switch_to_ada":0,
-          "predefined":[]
+          "clear_session":0,
+          "predefined":[],
+          "hide_client_login": true
         },
         "container_id":"sbw_5nb7uz"
       });

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -67,22 +67,37 @@ const Hero = () => {
           className="text-center max-w-4xl mx-auto"
         >
           {/* Main Headline - MEHR ABSTAND AUF MOBILE */}
-          <motion.h1 
+          <motion.h1
             className="text-4xl md:text-6xl lg:text-7xl font-serif mb-6 mt-20 sm:mt-0"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 1, delay: 0.2 }}
           >
-            Wenn sich Wege{' '}
-            <span className="text-gold inline-block animate-pulse">trennen</span>,
+            <span className="whitespace-nowrap">
+              Wenn sich Wege{' '}
+              <motion.span
+                className="text-gold inline-block animate-pulse"
+                animate={{
+                  opacity: [1, 0.7, 1],
+                }}
+                transition={{
+                  duration: 3,
+                  repeat: Infinity,
+                  ease: "easeInOut"
+                }}
+              >
+                trennen
+              </motion.span>
+              ,
+            </span>
             <br />
             beginnt dein{' '}
-            <motion.span 
+            <motion.span
               className="text-gold"
-              animate={{ 
+              animate={{
                 opacity: [1, 0.7, 1],
               }}
-              transition={{ 
+              transition={{
                 duration: 3,
                 repeat: Infinity,
                 ease: "easeInOut"
@@ -115,12 +130,14 @@ const Hero = () => {
               to="buchen"
               smooth={true}
               duration={500}
-              className="group relative px-12 py-6 bg-gradient-to-r from-gold to-dark-gold text-black font-bold rounded-full cursor-pointer overflow-hidden hover:scale-105 transition-all shadow-2xl hover:shadow-gold/50"
+              className="group relative px-8 py-4 bg-gradient-to-r from-gold to-dark-gold text-black font-bold rounded-full cursor-pointer overflow-hidden hover:scale-105 transition-all shadow-2xl hover:shadow-gold/50"
             >
-              <span className="relative z-10 text-xl">
+              <span className="relative z-10 text-lg">
                 Kostenloses Erstgespräch
-                <span className="block text-sm font-normal mt-1 opacity-90">
-                  30 Minuten • Unverbindlich • 100% kostenlos
+                <span className="block text-xs font-normal mt-1 opacity-90">
+                  30 Minuten • Unverbindlich
+                  <br className="sm:hidden" />
+                  <span className="sm:inline"> • </span>100% kostenlos
                 </span>
               </span>
             </Link>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -118,7 +118,7 @@ const Services = () => {
           viewport={{ once: true }}
           className="mb-12"
         >
-          <h3 className="text-2xl font-serif text-center mb-6 text-gray-300">Einzelstunden (ohne Erstgespräch)</h3>
+          <h3 className="text-2xl font-serif text-center mb-6 text-gray-300">Einzelstunden</h3>
           <div className="grid md:grid-cols-2 gap-4 max-w-2xl mx-auto mb-8">
             {einzelStunden.map((stunde, index) => (
               <motion.div


### PR DESCRIPTION
## Summary
- prevent the hero headline from breaking mid-phrase and tighten the CTA button copy and spacing
- remove the "(ohne Erstgespräch)" qualifier from the Einzelstunden heading
- ensure the about-page logo container remains perfectly circular and hide the SimplyBook.me client login button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef855b6f4832589a4cda62f87eb8e