### PR TITLE
Remove heart motifs from UI sections

### DIFF
--- a/src/components/EmotionBarometer.jsx
+++ b/src/components/EmotionBarometer.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Heart, Cloud, Flame, Sun, HelpCircle, Smile } from 'lucide-react';
+import { Cloud, Flame, Sun, HelpCircle, Smile, Compass } from 'lucide-react';
 
 const EmotionBarometer = ({ onEmotionSelect }) => {
   const [selectedEmotion, setSelectedEmotion] = useState(null);
@@ -58,7 +58,7 @@ const EmotionBarometer = ({ onEmotionSelect }) => {
     {
       id: 'unsicher',
       label: 'Unsicher',
-      icon: Heart,
+      icon: Compass,
       color: 'from-indigo-600 to-indigo-900',
       glow: 'shadow-indigo-500/50',
       response: {

--- a/src/components/FirstAidKit.jsx
+++ b/src/components/FirstAidKit.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { FileDown, Heart } from 'lucide-react';
+import { FileDown, Feather } from 'lucide-react';
 
 const FirstAidKit = () => {
   return (
@@ -17,7 +17,7 @@ const FirstAidKit = () => {
             Sanfter Download
           </span>
           <h2 className="text-4xl md:text-5xl font-serif mt-6 mb-4">
-            Erste Hilfe für dein Herz
+            Erste Hilfe für deinen Neuanfang
           </h2>
           <p className="text-gray-400 max-w-2xl mx-auto text-lg">
             Ein einseitiges PDF mit ruhigen Impulsen, das dich nach einer Trennung wieder atmen lässt.
@@ -38,7 +38,7 @@ const FirstAidKit = () => {
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
                 <div className="flex items-center gap-4">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gold/15 text-gold">
-                    <Heart size={26} />
+                    <Feather size={26} />
                   </div>
                   <p className="text-gray-300 text-base leading-relaxed max-w-md">
                     Eine kleine Soforthilfe, wenn alles zu viel wird – leicht verständlich, ruhig und wertschätzend.

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link as ScrollLink } from 'react-scroll';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { Instagram, Youtube, Mail, Shield, FileText, Heart, Code } from 'lucide-react';
+import { Instagram, Youtube, Mail, Shield, FileText, Code } from 'lucide-react';
 import logo from '../assets/logo.svg';
 
 const Footer = () => {
@@ -180,7 +180,7 @@ const Footer = () => {
             </p>
             <div className="flex flex-col sm:flex-row items-center gap-4 text-sm">
               <p className="text-gray-500 flex items-center gap-1">
-                Made with <Heart size={14} className="text-gold" fill="#B8860B" /> für Menschen in Veränderung
+                Mit Hingabe für Menschen in Veränderung erstellt
               </p>
               {/* VIDEONEERS CREDIT */}
               <a 


### PR DESCRIPTION
## Summary
- remove heart iconography from the footer credit line and adjust the wording to stay on-brand
- rename the first-aid download headline and swap the heart symbol for a feather accent
- replace the heart indicator in the emotion barometer with a compass icon to keep the tool consistent

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d695106f8083258b0eaab3f7c2941d